### PR TITLE
Balancing update v1.1.2

### DIFF
--- a/src/jsMain/kotlin/Automation.kt
+++ b/src/jsMain/kotlin/Automation.kt
@@ -104,6 +104,10 @@ class Clicker(val id: Int, val page: Page, var mode: ClickerMode, var autoCps: D
 
         if (mode == ClickerMode.MANUAL) canvasParent.classList.add("keyclicker")
         Input.addKeybind(KeyclickerKeybind(this))
+
+        GameTimer.nextTick {
+            moveToDock(true)
+        }
     }
 
     fun setMode(newMode: ClickerMode) {

--- a/src/jsMain/kotlin/Library.kt
+++ b/src/jsMain/kotlin/Library.kt
@@ -51,7 +51,7 @@ object SpecialReactions: Library<SpecialReaction>() {
             "Clockwork",
             {
                 elementStackOf(
-                    Elements.a to 60.0 + 60.0 * it
+                    Elements.a to 50.0 + 50.0 * it
                 )
             },
             effects = {
@@ -87,19 +87,19 @@ object SpecialReactions: Library<SpecialReaction>() {
             "Massive Clock",
             {
                 elementStackOf(
-                    Elements.d to 4.0 * it
+                    Elements.d to 2.0 * it.squared()
                 )
             },
             effects = {
                 GameTimer.registerTicker("massiveClockTicker") { dt ->
-                    val multiplier = 0.2 * it
+                    val multiplier = 0.1 * it + 0.1
                     val catalysts = max(0.0, min(dt * Stats.gameSpeed * multiplier * Stats.elementAmounts[Elements.d], Stats.functionalElementUpperBounds[Elements.catalyst] * .99 - Stats.elementAmounts[Elements.catalyst]))
                     gameState.incoming.add(elementStackOf(Elements.catalyst to catalysts))
                 }
             },
             stringEffects = {
-                val multiplier = 0.2 * it
-                "Each \"${Elements.d.symbol}\" generates \"${Elements.catalyst.symbol}\" at ${(multiplier - 0.2).roundToOneDecimalPlace()} → ${multiplier.roundToOneDecimalPlace()} per second (until 99% of cap)"
+                val multiplier = 0.1 * it + 0.1
+                "Each \"${Elements.d.symbol}\" generates \"${Elements.catalyst.symbol}\" at ${(multiplier - 0.1).roundToOneDecimalPlace()} → ${multiplier.roundToOneDecimalPlace()} per second (until 99% of cap)"
             },
             usageCap = 100
         )
@@ -109,7 +109,7 @@ object SpecialReactions: Library<SpecialReaction>() {
             "Heating Up",
             {
                 elementStackOf(
-                    Elements.b to 1000.0 + if (it <= 5) 0.0 else if (it <= 10) 200.0 * (it - 5) else 200.0 * (it - 5) * (it - 10)
+                    Elements.b to 1000.0 + if (it <= 3) 0.0 else if (it <= 7) 200.0 * (it - 3) else 200.0 * (it - 3) * (it - 7)
                 )
             },
             effects = {
@@ -126,7 +126,7 @@ object SpecialReactions: Library<SpecialReaction>() {
             "Overheat",
             {
                 elementStackOf(
-                    Elements.c to 4.0 * it
+                    Elements.c to 6.0 * it
                 )
             },
             effects = {
@@ -143,19 +143,19 @@ object SpecialReactions: Library<SpecialReaction>() {
             "Heat Sink",
             {
                 elementStackOf(
-                    Elements.d to 4.0 * it * it,
-                    Elements.heat to 2.0 * (it + 1) * (it + 1)
+                    Elements.d to 8.0 * it.squared(),
+                    Elements.heat to 2.0 * (it + 1).squared()
                 )
             },
             effects = {
                 NormalReactions.cminglyOp.apply {
                     inputs = inputs.mutateDefaulted { map ->
-                        map[Elements.heat] = 2.0 * (it + 2) * (it + 2)
+                        map[Elements.heat] = 2.0 * (it + 2).squared()
                     }
                 }
             },
             stringEffects = {
-                "Heat cost on \"${NormalReactions.cminglyOp.name}\" ${2 * (it + 1) * (it + 1)} → ${2 * (it + 2) * (it + 2)}"
+                "Heat cost on \"${NormalReactions.cminglyOp.name}\" ${2 * (it + 1).squared()} → ${2 * (it + 2).squared()}"
             },
             usageCap = 100
         )
@@ -166,7 +166,7 @@ object SpecialReactions: Library<SpecialReaction>() {
             {
                 elementStackOf(
                     Elements.e to 2.0.pow(it),
-                    Elements.b to 250.0 * 4.0.pow(it)
+                    Elements.b to 500.0 * 4.0.pow(it)
                 )
             },
             effects = {
@@ -271,11 +271,11 @@ object NormalReactions: Library<Reaction>() {
             "ABCs",
             elementStackOf(
                 Elements.catalyst to 2.0,
-                Elements.b to 16.0,
+                Elements.b to 23.0,
             ),
             elementStackOf(
                 Elements.c to 1.0,
-                Elements.heat to 5.0
+                Elements.heat to 4.0
             )
         )
     )
@@ -319,7 +319,7 @@ object NormalReactions: Library<Reaction>() {
         Reaction(
             "Over 900",
             elementStackOf(
-                Elements.b to 950.0,
+                Elements.b to 901.0,
             ),
             elementStackOf(
                 Elements.d to 3.0
@@ -330,8 +330,9 @@ object NormalReactions: Library<Reaction>() {
         Reaction(
             "Exotherm",
             elementStackOf(
-                Elements.c to 20.0,
-                Elements.catalyst to 1000.0
+                Elements.c to 60.0,
+                Elements.a to 1000.0,
+                Elements.catalyst to 3000.0
             ),
             elementStackOf(
                 Elements.e to 1.0,

--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -16,7 +16,7 @@ lateinit var gameState: GameState
 
 var reactionListScrollAmount = 0.0
 var reactionListScrollSens = 0.4
-const val gameVersion = "v1.1.1"
+const val gameVersion = "v1.1.2"
 
 @OptIn(ExperimentalJsExport::class)
 @JsExport

--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -26,6 +26,8 @@ fun resetSave() {
 }
 
 val notation = RateOfChangeNotation.MAXPERSEC
+val htmlUpdateInterval = 5.0
+var lastHtmlUpdate = 0.0
 
 @OptIn(ExperimentalJsExport::class)
 @Suppress("RedundantUnitExpression")
@@ -40,10 +42,12 @@ fun loadGame() {
     GameTimer.registerTicker("HTML updates") {
         val prefix = notation.prefix
         val suffix = notation.suffix
+        val updateAll = GameTimer.timeSex() - lastHtmlUpdate > htmlUpdateInterval
+        if (updateAll) lastHtmlUpdate = GameTimer.timeSex()
         DynamicHTMLManager.apply {
             for ((name, element) in Elements.map) {
                 val symbol = element.symbol
-                if (Stats.elementAmounts.changed(element)) {
+                if (updateAll || Stats.elementAmounts.changed(element)) {
                     val displayText =
                         "${if (element.isDecimal) Stats.elementAmounts[element].roundTo(2) else floor(Stats.elementAmounts[element])}"
                     setVariable(
@@ -56,7 +60,7 @@ fun loadGame() {
                     )
                     Stats.elementAmounts.clearChanged(element)
                 }
-                if (Stats.functionalElementLowerBounds.changed(element) || Stats.functionalElementUpperBounds.changed(element)) {
+                if (updateAll || Stats.functionalElementLowerBounds.changed(element) || Stats.functionalElementUpperBounds.changed(element)) {
                     setVariable(
                         "$symbol-bounds-display",
                         "${Stats.functionalElementLowerBounds[element].roundTo(2)} ≤ $symbol ≤ ${
@@ -68,14 +72,14 @@ fun loadGame() {
                     Stats.functionalElementLowerBounds.clearChanged(element)
                     Stats.functionalElementUpperBounds.clearChanged(element)
                 }
-                if (Stats.elementRates.changed(element)) {
+                if (updateAll || Stats.elementRates.changed(element)) {
                     setVariable(
                         "$symbol-rate-display",
                         "current $symbol / s = ${Stats.elementRates[element].roundTo(2)}"
                     )
                     Stats.elementRates.clearChanged(element)
                 }
-                if (Stats.elementDeltas.changed(element)) {
+                if (updateAll || Stats.elementDeltas.changed(element)) {
                     setVariable(
                         "$symbol-max-rate-display",
                         "$prefix$symbol$suffix = ${Stats.elementDeltas[element].roundTo(2)}"


### PR DESCRIPTION
Full changelog:
- Made Clockwork cheaper
- Significantly nerfed Massive Clock (cost scales quadratically and benefit scales by half)
- Made Heating Up scaling start at 3 upgrades instead of 5
- Made Overheat cost scale faster
- Made Heat Sink d cost scale faster
- Made Exponential cost double the b's
- Decreased heat gain from ABCs
- Made Over 900 cheaper
- Tripled Exotherm costs and added a 1000a cost
- Made ABCs cost 23b instead of 16b
- Fixed a bug I thought I fixed earlier